### PR TITLE
Resolve Routing Issue for Page1 and Detail PagesFix routing for Page1 and its detail pages

### DIFF
--- a/src/route/Page1Routes.jsx
+++ b/src/route/Page1Routes.jsx
@@ -6,7 +6,7 @@ import { Page1DetailB } from "../Page1DetailB"
 
 export const page1Routes = [
     {
-        path: "/",
+        path: "/page1",
         exact: true,
         children: <Page1 />
     },

--- a/src/route/Router.jsx
+++ b/src/route/Router.jsx
@@ -11,14 +11,14 @@ import { page1Routes } from './Page1Routes';
 export const Router = () =>{
     return(
     // <BrowserRouter>
-        
+
         <Routes>
-            <Route exact path="/" element={<Home />}></Route>
+            <Route path="/" element={<Home />}/>
             {page1Routes.map((route)=>{
                 return(
                     <Route
                     key={route.path}
-                    exact={route.exact}
+                    path={route.path}
                     element={route.children}
                     >
                 </Route>
@@ -28,8 +28,8 @@ export const Router = () =>{
             {/* <Route exact path="/page1" element={<Page1 />}></Route> */}
             {/* <Route exact path = "/page1/detailA" element={<Page1DetailA/>}></Route>
             <Route exact path = "/page1/detailB" element={<Page1DetailB/>}></Route> */}
-            <Route exact path="/page2" element={<Page2 />}></Route>
-            <Route exact path='*' element={<NoMatch/>} ></Route>
+            <Route path="/page2" element={<Page2 />} />
+            <Route path='*' element={<NoMatch/>} />
         </Routes>
     // </BrowserRouter>
     )


### PR DESCRIPTION
This PR addresses the problem where the Page1DetailA and Page1DetailB components were not being displayed correctly when clicking on Page1. The issue was due to a path conflict in the routing configuration and the incorrect use of the 'exact' property in the Route component.

Changes include:
1. Updating the routing path for Page1 from '/' to '/page1' to avoid path conflicts with the Home component.
2. Removing the 'exact' property from the Route component as it's not required in React Router v6.

With these changes, clicking on Page1 now correctly displays the Page1DetailA and Page1DetailB components. This PR ensures that the application's routing works as expected, improving the overall user experience.